### PR TITLE
Formatting: Removed duplication of code block

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,11 +40,11 @@ Current version (1.0.0) of ``pydbgen`` comes with the following primary methods,
 
 The ``gen_table()`` method allows you to build a database with as many tables as you want, filled with random data and fields of your choice. But first, you have to create an object of ``pydb`` class::
 	
-	```
+
 	import pydbgen
 	from pydbgen import pydbgen
 	myDB = pydbgen.pydb()
-	```
+
 
 Generate *Pandas series object*: ``gen_data_series()``
 --------------------------------------------------------


### PR DESCRIPTION
I've just spotted that combining an indentation AND the ``` tag just adds "```" into the code block itself.